### PR TITLE
Fix 'Null' classname when WebsocketHandlerInterface is not properly implemented

### DIFF
--- a/src/Swoole/Server.php
+++ b/src/Swoole/Server.php
@@ -113,7 +113,7 @@ class Server
         $handlerClass = $this->conf['websocket']['handler'];
         $t = new $handlerClass();
         if (!($t instanceof WebsocketHandlerInterface)) {
-            throw new \Exception(sprintf('%s must implement the interface %s', get_class($handler), WebsocketHandlerInterface::class));
+            throw new \Exception(sprintf('%s must implement the interface %s', get_class($t), WebsocketHandlerInterface::class));
         }
         $handler = $t;
         return $handler;


### PR DESCRIPTION
There is a miswriting of classname to be printed.
With original code given as `$handler` which refers to the undefined `null` object, exception messages here wouldn't be shown as expected.
Thus a quick fix to replace `$handler` with intented `$t` here is required.