### PR TITLE
Enable timers to run immediately after setting up.

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -468,6 +468,10 @@ class TestCronJob extends CronJob
     {
         return 1000;// 每1秒运行一次
     }
+    public function isImmediate()
+    {
+        return false;// 是否立即执行第一次，false则等待间隔时间后执行第一次
+    }
     public function run()
     {
         \Log::info(__METHOD__, ['start', $this->i, microtime(true)]);

--- a/README.md
+++ b/README.md
@@ -469,6 +469,10 @@ class TestCronJob extends CronJob
     {
         return 1000;// Run every 1000ms
     }
+    public function isImmediate()
+    {
+        return false;// Whether to trigger `run` immediately after setting up
+    }
     public function run()
     {
         \Log::info(__METHOD__, ['start', $this->i, microtime(true)]);

--- a/src/Illuminate/LaravelScheduleJob.php
+++ b/src/Illuminate/LaravelScheduleJob.php
@@ -18,6 +18,11 @@ class LaravelScheduleJob extends CronJob
         return 60 * 1000;// Run every 1 minute
     }
 
+    public function isImmediate()
+    {
+        return false;
+    }
+    
     public function run()
     {
         $this->artisan->call('schedule:run');

--- a/src/Swoole/Timer/CronJob.php
+++ b/src/Swoole/Timer/CronJob.php
@@ -22,4 +22,12 @@ abstract class CronJob implements CronJobInterface
         }
     }
 
+    /**
+     * @return bool $isImmediate
+     */
+    public function isImmediate()
+    {
+        return false;
+    }
+
 }

--- a/src/Swoole/Timer/CronJobInterface.php
+++ b/src/Swoole/Timer/CronJobInterface.php
@@ -11,6 +11,11 @@ interface CronJobInterface
      */
     public function interval();
 
+    /**
+     * @return bool $isImmediate
+     */
+    public function isImmediate();
+    
     public function run();
 
     public function stop();

--- a/src/Swoole/Traits/TimerTrait.php
+++ b/src/Swoole/Traits/TimerTrait.php
@@ -30,6 +30,15 @@ trait TimerTrait
                     }
                 });
                 $job->setTimerId($timerId);
+                if ($job->isImmediate()) {
+                    swoole_timer_after(1, function () use ($job) {
+                        try {
+                            $job->run();
+                        } catch (\Exception $e) {
+                            $this->logException($e);
+                        }
+                    });
+                }
             }
         };
 


### PR DESCRIPTION
I noticed that once the CrobJob has been set up, then it's gonna take a whole interval time for the timer to tick for the first time.  In some occasions, an immediate tick is neccesary. I managed to achieve this by adding property getter `isImmediate` and a few lines using `swoole_timer_after`.

Note: This change is not compatible with the previous CronJobs. `isImmediate` need to be added to the previous CronJob implementation to run properly.

注意到定时任务 CrobJob 在设定好后并不会马上执行第一次，而会等待第一个时间间隔后执行第一次。而在某些情况下，特别是对于时间间隔很长的任务，设定 CrobJob 后立即执行第一次是很必要的。通过添加属性 getter `isImmediate` 并调用 `swoole_timer_after`，这个需求已经被实现。

注意：该改动并不兼容之前的CronJob。需要为之前实现的CronJob添加isImmediate方法后才能正常运行。