### PR TITLE
Fix lumens 'Laravel->__clone()' error.

### DIFF
--- a/src/Illuminate/Laravel.php
+++ b/src/Illuminate/Laravel.php
@@ -323,6 +323,9 @@ class Laravel
     public function __clone()
     {
         $this->app = clone $this->app;
-        $this->laravelKernel = clone $this->laravelKernel;
+
+        if (!$this->conf['is_lumen']) {
+            $this->laravelKernel = clone $this->laravelKernel;
+        }
     }
 }


### PR DESCRIPTION
Laravels kernel should not be cloned in lumen projects.

Resolves #79 .