### PR TITLE
support parameters for the constructor of cron job

### DIFF
--- a/config/laravels.php
+++ b/config/laravels.php
@@ -33,6 +33,7 @@ return [
             // Enable LaravelScheduleJob to run `php artisan schedule:run` every 1 minute, replace Linux Crontab
             //\Hhxsv5\LaravelS\Illuminate\LaravelScheduleJob::class,
             //XxxCronJob::class,
+            // [XxxCronJob::class, ARGS_INTO_CONSTRUCT]
         ],
     ],
     'events'             => [

--- a/src/Swoole/Traits/TimerTrait.php
+++ b/src/Swoole/Traits/TimerTrait.php
@@ -20,7 +20,15 @@ trait TimerTrait
             $this->setProcessTitle(sprintf('%s laravels: timer process', $config['process_prefix']));
             $this->initLaravel($laravelConfig, $swoole);
             foreach ($config['jobs'] as $jobClass) {
-                $job = new $jobClass();
+                if (is_array($jobClass)) {
+                    if (isset($jobClass[1])) {
+                        $job = new $jobClass[0]($jobClass[1]);
+                    } else {
+                        $job = new $jobClass[0]();
+                    }
+                } else {
+                    $job = new $jobClass();
+                }
                 if (!($job instanceof CronJob)) {
                     throw new \Exception(sprintf('%s must implement the abstract class %s', get_class($job), CronJob::class));
                 }


### PR DESCRIPTION
变数量的参数不知如何兼容，直接去掉了数组参数的有序传入。目前的写法解释为jobs下若有数组形式的XXXCronJob注册时，支持第二个元素作为唯一参数传入XXXCronJob的构造函数。