### PR TITLE
update fire to dispatch function

### DIFF
--- a/src/Illuminate/Laravel.php
+++ b/src/Illuminate/Laravel.php
@@ -276,7 +276,7 @@ class Laravel
     public function fireEvent($name, array $params = [])
     {
         $params[] = $this->app;
-        return $this->app->events->fire($name, $params);
+        return $this->app->events->dispatch($name, $params);
     }
 
     public function bindRequest(IlluminateRequest $request)


### PR DESCRIPTION
Illuminate/Events/Dispatcher 类中的fire 方法 （在Larevel 5.4中不赞成使用）Larevel 5.8 已经被移除 了。
你应当使用它的替代方法 dispatch ,否则会报如下错误：
Oops! An unexpected error occurred: Call to undefined method Illuminate\Events\Dispatcher::fire()

5.7
Illuminate\Events\Dispatcher
···
    public function fire($event, $payload = [], $halt = false)
    {
        return $this->dispatch($event, $payload, $halt);
    }
···