### PR TITLE
Decode uri for support non-ascii file name.

### DIFF
--- a/src/Illuminate/Laravel.php
+++ b/src/Illuminate/Laravel.php
@@ -173,6 +173,7 @@ class Laravel
         if (isset(self::$staticBlackList[$uri])) {
             return false;
         }
+        $uri = urldecode($uri);
 
         $publicPath = $this->conf['static_path'];
         $requestFile = $publicPath . $uri;


### PR DESCRIPTION
Currently when filename contains non-ascii character,  it will cause `is_file($requestFile)` and `is_dir($requestFile)` return false in `\Hhxsv5\LaravelS\Illuminate\Laravel::handleStatic`, and finally return a 404 response, as `$request->getRequestUri();` will return an encoded uri, server cannot find the file with this encoded uri.