### PR TITLE
Add feature to monitor worker processes in real time

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -1053,6 +1053,92 @@ class WebSocketService implements WebSocketHandlerInterface
         var_dump($pushProcess->read());
     }
     ```
+   
+## 获取 Worker 当前状态
+
+> 依赖于 ext-sockets。用以快速定位 worker 正在被什么请求阻塞了。
+
+1. 检查 `ext-sockets` 是否启用
+
+```
+php -m | grep sockets
+```
+
+2. 添加配置到 `.env`
+
+```
+LARAVELS_ENABLE_STATUS_MONITOR=true
+```
+
+3. 添加配置到 `laravels.php`
+
+```
+'enable_laravels_status_monitor' => env('LARAVELS_ENABLE_STATUS_MONITOR', true),
+```
+
+4. 添加自定义进程配置到 `laravels.php`
+
+```
+'status_monitor' => [
+    'class'    => \Hhxsv5\LaravelS\Illuminate\LaravelSMonitorProcess::class,
+    'redirect' => false,
+    'pipe'     => 1,
+    'enable'   => env('LARAVELS_ENABLE_STATUS_MONITOR', true) && extension_loaded('sockets'),
+],
+```
+
+5. 添加 swoole table 定义到 `laravels.php`
+
+```
+'status' => [
+    'size' => 30,
+    'column' => [
+        ['name' => 'value', 'type' => \Swoole\Table::TYPE_STRING, 'size' => 256],
+    ]
+],
+```
+
+6. 重启 laravels
+
+7. 获取 worker 当前状态
+
+```
+cat storage/swoole-status.sock
+```
+
+或者
+
+````
+php artisan laravels:status
+````
+
+输出:
+
+```
+{
+    "start_time": 1584767471,
+    "connection_num": 2,
+    "accept_count": 2,
+    "close_count": 0,
+    "worker_num": 8,
+    "idle_worker_num": 6,
+    "tasking_num": 0,
+    "request_count": 0,
+    "worker_request_count": 0,
+    "worker_dispatch_count": 0,
+    "coroutine_num": 1,
+    "start_times": {
+        "worker_0": "",
+        "worker_1": "",
+        "worker_2": "",
+        "worker_3": "GET /b 6.39s (Time elapsed) (started_at: 2020-03-21 05:11:14)",
+        "worker_4": "GET /a 25.5s (Time elapsed) (started_at: 2020-03-21 05:11:17)",
+        "worker_5": "",
+        "worker_6": "",
+        "worker_7": ""
+    }
+}
+```
 
 ## 其他特性
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Table of Contents
 
 - Simple & Out of the box
 
+- Get worker current status
+
 ## Requirements
 
 | Dependency | Requirement |
@@ -1041,6 +1043,92 @@ To make our main server support more protocols not just Http and WebSocket, we b
         var_dump($pushProcess->read());
     }
     ```
+
+## Get worker current status
+
+> Relied on ext-sockets. Find out which request is blocking in worker quickly.
+
+1. Check if `ext-sockets` is enabled.
+
+```
+php -m | grep sockets
+```
+
+2. Add config to `.env`
+
+```
+LARAVELS_ENABLE_STATUS_MONITOR=true
+```
+
+3. Add config to `laravels.php`
+
+```
+'enable_laravels_status_monitor' => env('LARAVELS_ENABLE_STATUS_MONITOR', true),
+```
+
+4. Add custom process to `laravels.php`
+
+```
+'status_monitor' => [
+    'class'    => \Hhxsv5\LaravelS\Illuminate\LaravelSMonitorProcess::class,
+    'redirect' => false,
+    'pipe'     => 1,
+    'enable'   => env('LARAVELS_ENABLE_STATUS_MONITOR', true) && extension_loaded('sockets'),
+],
+```
+
+5. Add swoole table definition to `laravels.php`
+
+```
+'status' => [
+    'size' => 30,
+    'column' => [
+        ['name' => 'value', 'type' => \Swoole\Table::TYPE_STRING, 'size' => 256],
+    ]
+],
+```
+
+6. Restart laravels
+
+7. Get the worker status
+
+```
+cat storage/swoole-status.sock
+```
+
+or
+
+````
+php artisan laravels:status
+````
+
+output:
+
+```
+{
+    "start_time": 1584767471,
+    "connection_num": 2,
+    "accept_count": 2,
+    "close_count": 0,
+    "worker_num": 8,
+    "idle_worker_num": 6,
+    "tasking_num": 0,
+    "request_count": 0,
+    "worker_request_count": 0,
+    "worker_dispatch_count": 0,
+    "coroutine_num": 1,
+    "start_times": {
+        "worker_0": "",
+        "worker_1": "",
+        "worker_2": "",
+        "worker_3": "GET /b 6.39s (Time elapsed) (started_at: 2020-03-21 05:11:14)",
+        "worker_4": "GET /a 25.5s (Time elapsed) (started_at: 2020-03-21 05:11:17)",
+        "worker_5": "",
+        "worker_6": "",
+        "worker_7": ""
+    }
+}
+```
 
 ## Other features
 

--- a/config/laravels.php
+++ b/config/laravels.php
@@ -11,6 +11,7 @@ return [
     'server'                   => env('LARAVELS_SERVER', 'LaravelS'),
     'handle_static'            => env('LARAVELS_HANDLE_STATIC', false),
     'laravel_base_path'        => env('LARAVEL_BASE_PATH', base_path()),
+    'enable_laravels_status_monitor' => env('LARAVELS_ENABLE_STATUS_MONITOR', true),
     'inotify_reload'           => [
         'enable'        => env('LARAVELS_INOTIFY_RELOAD', false),
         'watch_path'    => base_path(),
@@ -31,6 +32,13 @@ return [
         //    'pipe'     => 0 // The type of pipeline, 0: no pipeline 1: SOCK_STREAM 2: SOCK_DGRAM
         //    'enable'   => true // Whether to enable, default true
         //],
+        // Process to get current worker status
+        'status_monitor' => [
+            'class'    => \Hhxsv5\LaravelS\Illuminate\LaravelSMonitorProcess::class,
+            'redirect' => false,
+            'pipe'     => 1,
+            'enable'   => env('LARAVELS_ENABLE_STATUS_MONITOR', true) && extension_loaded('sockets'),
+        ],
     ],
     'timer'                    => [
         'enable'        => env('LARAVELS_TIMER', false),
@@ -44,7 +52,15 @@ return [
         'max_wait_time' => 5,
     ],
     'events'                   => [],
-    'swoole_tables'            => [],
+    'swoole_tables'            => [
+        // Recording current worker handle status
+        'status' => [
+            'size' => 30,
+            'column' => [
+                ['name' => 'value', 'type' => \Swoole\Table::TYPE_STRING, 'size' => 256],
+            ]
+        ],
+    ],
     'register_providers'       => [],
     'cleaners'                 => [
         // See LaravelS's built-in cleaners: https://github.com/hhxsv5/laravel-s/blob/master/Settings.md#cleaners

--- a/src/Illuminate/LaravelSMonitorProcess.php
+++ b/src/Illuminate/LaravelSMonitorProcess.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Hhxsv5\LaravelS\Illuminate;
+
+use Hhxsv5\LaravelS\Swoole\Process\CustomProcessInterface;
+use Illuminate\Support\Carbon;
+use Swoole\Http\Server;
+use Swoole\Process;
+use Illuminate\Support\Arr;
+
+/**
+ * Monitor which uri is handling by Laravel-S
+ */
+class LaravelSMonitorProcess implements CustomProcessInterface
+{
+    private static $quit = false;
+
+    /**
+     * @inheritDoc
+     */
+    public static function getName()
+    {
+        return "laravel-s status monitor";
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function callback(Server $swoole, Process $process)
+    {
+        if (!extension_loaded('sockets')) {
+            echo "ext-sockets is disabled, laravel-s monitor process will not working." . PHP_EOL;
+            return;
+        }
+
+        $socket = socket_create(AF_UNIX, SOCK_STREAM, 0);
+        $file = static::sockFile();
+        if (file_exists($file)) {
+            @unlink($file);
+        }
+        socket_bind($socket, $file);
+        socket_listen($socket);
+
+        chmod($file, 0777);
+        while (true) {
+            $sock = socket_accept($socket);
+            socket_write($sock, static::getSwooleStatus());
+            socket_close($sock);
+        }
+    }
+
+    /**
+     * Get current status of Laravel-S worker
+     *
+     * @return string
+     */
+    public static function getSwooleStatus()
+    {
+        $data = app('swoole')->stats();
+        $workerNum = config('laravels.swoole.worker_num');
+
+        for ($i = 0; $i < $workerNum; $i++) {
+            $value = Arr::get(app('swoole')->statusTable->get('worker:' . $i), 'value', '');
+
+            if ($value) {
+                $value = json_decode($value, true);
+                $value['started_at'] = Carbon::createFromTimestamp(ceil($value['start_time'] / 1000))->toDateTimeString();
+                $value['time'] = ceil(microtime(true) * 1000) - $value['start_time'];
+                $value['time'] = static::formatMillisecond($value['time']) . " (Time elapsed)";
+
+                $value = "{$value['method']} {$value['request_url']} {$value['time']} (started_at: {$value['started_at']})";
+            }
+
+            $data['start_times']['worker_' . $i] = $value;
+        }
+
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    }
+
+    /**
+     * Convert millisecond to human-readable format
+     *
+     * @param int $millisecond
+     * @return string
+     */
+    private static function formatMillisecond($millisecond)
+    {
+        if ($millisecond < 1000) {
+            // < 1s
+            $result = $millisecond . "ms";
+        } elseif ($millisecond < 1000 * 60) {
+            // 1s < time < 1min
+            $result = round($millisecond / 1000, 2) . "s";
+        } else {
+            // 1min < time
+            $result = round($millisecond / 1000 * 60, 2) . "min";
+        }
+
+        return $result;
+    }
+
+    /**
+     * Sock file to recording current Laravel-S worker status
+     *
+     * @return string
+     */
+    public static function sockFile()
+    {
+        return storage_path("swoole-status.sock");
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function onReload(Server $swoole, Process $process)
+    {
+        static::$quit = true;
+    }
+}

--- a/src/Illuminate/LaravelSServiceProvider.php
+++ b/src/Illuminate/LaravelSServiceProvider.php
@@ -22,6 +22,7 @@ class LaravelSServiceProvider extends ServiceProvider
         $this->commands([
             LaravelSCommand::class,
             ListPropertiesCommand::class,
+            LaravelSStatusCommand::class,
         ]);
     }
 }

--- a/src/Illuminate/LaravelSStatusCommand.php
+++ b/src/Illuminate/LaravelSStatusCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Hhxsv5\LaravelS\Illuminate;
+
+use Illuminate\Console\Command;
+
+class LaravelSStatusCommand extends Command
+{
+    protected $signature = "laravels:status";
+
+    protected $description = "Check which uri worker is processing, and how long has been taken";
+
+    public function fire()
+    {
+        return $this->handle();
+    }
+
+    public function handle()
+    {
+        $file = LaravelSMonitorProcess::sockFile();
+
+        if (file_exists($file)) {
+            $socket = socket_create(AF_UNIX, SOCK_STREAM, 0);
+
+            socket_connect($socket, $file);
+
+            $status = socket_read($socket, 2048);
+
+            socket_close($socket);
+
+            echo trim($status) . "\n";
+        }
+    }
+}


### PR DESCRIPTION
Sometimes worker process seems like not working at all, it may be blocking by some extreme-slow requests.

So we want to know which request result in this situation, this is written for this purpose.

We write the request information into `swoole table`, including request started time and request uri. And then we can get these information by `cat storage/swoole-status.sock` or `php artisan laravels:status`:

```
{
    "start_time": 1584767471,
    "connection_num": 2,
    "accept_count": 2,
    "close_count": 0,
    "worker_num": 8,
    "idle_worker_num": 6,
    "tasking_num": 0,
    "request_count": 0,
    "worker_request_count": 0,
    "worker_dispatch_count": 0,
    "coroutine_num": 1,
    "start_times": {
        "worker_0": "",
        "worker_1": "",
        "worker_2": "",
        "worker_3": "GET /b 6.39s (Time elapsed) (started_at: 2020-03-21 05:11:14)",
        "worker_4": "GET /a 25.5s (Time elapsed) (started_at: 2020-03-21 05:11:17)",
        "worker_5": "",
        "worker_6": "",
        "worker_7": ""
    }
}
```

Now we know which request is slow clearly.
