### PR TITLE
to control whether a `socket` can be used

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -846,6 +846,7 @@ class WebSocketService implements WebSocketHandlerInterface
                 'package_eof'    => "\r\n",
             ],
             'handler'  => \App\Sockets\TestTcpSocket::class,
+            'enable'   => true, // 是否启用，默认为true
         ],
     ],
     ```

--- a/README.md
+++ b/README.md
@@ -834,6 +834,7 @@ To make our main server support more protocols not just Http and WebSocket, we b
                 'package_eof'    => "\r\n",
             ],
             'handler'  => \App\Sockets\TestTcpSocket::class,
+            'enable'   => true, // whether to enable, default true
         ],
     ],
     ```

--- a/src/Illuminate/LaravelSCommand.php
+++ b/src/Illuminate/LaravelSCommand.php
@@ -153,6 +153,10 @@ EOS;
         ];
         $sockets = isset($config['server']['sockets']) ? $config['server']['sockets'] : [];
         foreach ($sockets as $key => $socket) {
+            if (isset($socket['enable']) && !$socket['enable']) {
+                continue;
+            }
+
             $name = 'Port#' . $key . ' ';
             $name .= isset($socketTypeNames[$socket['type']]) ? $socketTypeNames[$socket['type']] : 'Unknown socket';
             $tableRows [] = [

--- a/src/Swoole/Server.php
+++ b/src/Swoole/Server.php
@@ -125,6 +125,10 @@ class Server
     protected function bindAttachedSockets()
     {
         foreach ($this->attachedSockets as $socket) {
+            if (isset($socket['enable']) && !$socket['enable']) {
+                continue;
+            }
+
             $port = $this->swoole->addListener($socket['host'], $socket['port'], $socket['type']);
             if (!($port instanceof Port)) {
                 $errno = method_exists($this->swoole, 'getLastError') ? $this->swoole->getLastError() : 'unknown';


### PR DESCRIPTION
I don't want to run all `socket` on every machine, so i need to control whether a `socket` can be used by config.