### PR TITLE
Added config to force scheme for the server request.

### DIFF
--- a/config/laravels.php
+++ b/config/laravels.php
@@ -95,6 +95,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | HTTP Force SSL
+    |--------------------------------------------------------------------------
+    |
+    | With this set, Swoole Server will place the header "Scheme", used by
+    | laravel to define routes though the application. This is important if
+    | you are using Swoole alone (not using nginx/apache proxy).
+    |
+    */
+    'http_force_ssl' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Inotify Reload
     |--------------------------------------------------------------------------
     |

--- a/config/laravels.php
+++ b/config/laravels.php
@@ -103,7 +103,7 @@ return [
     | you are using Swoole alone (not using nginx/apache proxy).
     |
     */
-    'http_force_ssl' => true,
+    'http_force_ssl' => env('LARAVELS_HTTP_FORCE_SSL', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/laravels.php
+++ b/config/laravels.php
@@ -99,7 +99,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | With this set, Swoole Server will place the header "Scheme", used by
-    | laravel to define routes though the application. This is important if
+    | laravel to define routes through the application. This is important if
     | you are using Swoole alone (not using nginx/apache proxy).
     |
     */

--- a/src/Swoole/Request.php
+++ b/src/Swoole/Request.php
@@ -55,6 +55,14 @@ class Request
             }
         }
         $server = array_change_key_case($server, CASE_UPPER);
+
+        if (
+            config('laravels.http_force_ssl', false)
+            && !isset($server['REQUEST_SCHEME'])
+        ) {
+            $server['REQUEST_SCHEME'] = 'https';
+        }
+
         $_SERVER = array_merge($_SERVER, $server);
         if (isset($_SERVER['REQUEST_SCHEME']) && $_SERVER['REQUEST_SCHEME'] === 'https') {
             $_SERVER['HTTPS'] = 'on';


### PR DESCRIPTION
Hello,

I'm looking forward to hear others opinion in this subject. While trying to set up a Swoole server along, without any proxy, I faced the challenge of not being able to properly make sure that all the routes in the application had the same scheme (HTTPS). After some investigation I noticed that what was failing was the fact that Swoole (I'm using 4.6.6, but I tested since 4.5.*) is not adding to the request the 'scheme'.

I wonder if this is a problem on my local, but after many different combinations, php8.0-cli, php7.4-cli, laravel 8, bare metal, dockerized, I get the same always.

That said, I added this fix, that worked for all the tests that I did, and for all the helpers and routes generators through laravel.

IF this is something thet others are also experiencing, it might be helpful.  