### PR TITLE
Update Request.php

### DIFF
--- a/src/Swoole/Request.php
+++ b/src/Swoole/Request.php
@@ -78,7 +78,7 @@ class Request
         IlluminateRequest::enableHttpMethodParameterOverride();
         $request = IlluminateRequest::createFromBase(new \Symfony\Component\HttpFoundation\Request($__GET, $__POST, [], $__COOKIE, $__FILES, $_SERVER, $__CONTENT));
 
-        if (0 === strpos($request->headers->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
+        if (0 === strpos($request->headers->get('CONTENT_TYPE', ''), 'application/x-www-form-urlencoded')
             && in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), ['PUT', 'DELETE', 'PATCH'])
         ) {
             parse_str($request->getContent(), $data);


### PR DESCRIPTION
修复在 PHP 8.1.4 中 strpos(): Passing null to parameter #1 ($haystack) of type string 问题。
测试时发现部分客户端未指定 Content-Type 导致读取 header 错误