### PR TITLE
Expose Swoole\Http\Response

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -67,6 +67,7 @@
 * [其他特性](#其他特性)
     * [配置Swoole事件](#配置Swoole事件)
     * [Serverless](#serverless)
+    * [使用Swoole\Http\Response](https://github.com/hhxsv5/laravel-s/blob/feature/custom-swoole-response/Settings-CN.md#expose_swoole_http_response)
 * [注意事项](#注意事项)
 * [用户与案例](#用户与案例)
 * [其他选择](#其他选择)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Table of Contents
 * [Other features](#other-features)
     * [Configure Swoole events](#configure-swoole-events)
     * [Serverless](#serverless)
+    * [Use Swoole\Http\Response](https://github.com/hhxsv5/laravel-s/blob/feature/custom-swoole-response/Settings.md#expose_swoole_http_response)
 * [Important notices](#important-notices)
 * [Users and cases](https://github.com/hhxsv5/laravel-s/blob/master/README-CN.md#%E7%94%A8%E6%88%B7%E4%B8%8E%E6%A1%88%E4%BE%8B)
 * [Alternatives](#alternatives)

--- a/Settings-CN.md
+++ b/Settings-CN.md
@@ -123,5 +123,16 @@
 ## expose_swoole_http_response
 > `bool` 是否暴露`Swoole\Http\Response`对象，用于用此对象直接响应，比如调用它的write()、sendfile()等方法，但Laravel后置中间件可能不会正常工作，默认`false`。
 
+```php
+// 将expose_swoole_http_response设置为true
+$router->get('/custom-swoole-response', function () use ($router) {
+    /**@var \Swoole\Http\Response $swooleResponse */
+    $swooleResponse = app('swoole-http-response');
+    $swooleResponse->end('swoole response');
+    $swooleResponse->isEnded = true; // 必须将isEnded设置为true，表示直接使用底层的Swoole\Http\Response对象来处理响应，从而会响应"swoole response"而不是"laravel response"
+    return 'laravel response';
+});
+```
+
 ## swoole
 > `array` Swoole的`原始`配置项，请参考[Swoole服务器配置项](https://wiki.swoole.com/#/server/setting)。

--- a/Settings-CN.md
+++ b/Settings-CN.md
@@ -120,5 +120,8 @@
 ## destroy_controllers
 > `array` 每次请求后自动销毁控制器，解决单例控制器的问题，参考[示例](https://github.com/hhxsv5/laravel-s/blob/master/KnownIssues-CN.md#%E5%8D%95%E4%BE%8B%E6%8E%A7%E5%88%B6%E5%99%A8)。
 
+## expose_swoole_http_response
+> `bool` 是否暴露`Swoole\Http\Response`对象，用于用此对象直接响应，比如调用它的write()、sendfile()等方法，但Laravel后置中间件可能不会正常工作，默认`false`。
+
 ## swoole
 > `array` Swoole的`原始`配置项，请参考[Swoole服务器配置项](https://wiki.swoole.com/#/server/setting)。

--- a/Settings.md
+++ b/Settings.md
@@ -123,5 +123,16 @@
 ## expose_swoole_http_response
 > `bool` Whether to expose the `Swoole\Http\Response` object for direct response with this object, such as calling its write(), sendfile() and other methods, but Laravel after-middleware may not work properly, default `false`.
 
+```php
+// Set expose_swoole_http_response to true
+$router->get('/custom-swoole-response', function () use ($router) {
+    /**@var \Swoole\Http\Response $swooleResponse */
+    $swooleResponse = app('swoole-http-response');
+    $swooleResponse->end('swoole response');
+    $swooleResponse->isEnded = true; // isEnded must be set to true, indicating that the underlying Swoole\Http\Response object is directly used to process the response, so the response content is "swoole response" instead of "laravel response".
+    return 'laravel response';
+});
+```
+
 ## swoole
 > `array` Swoole's `original` configuration items, refer [Swoole Server Configuration](https://www.swoole.co.uk/docs/modules/swoole-server/configuration).

--- a/Settings.md
+++ b/Settings.md
@@ -120,5 +120,8 @@
 ## destroy_controllers
 > `array` Automatically destroy the controllers after each request to solve the problem of the singleton controllers, refer [Demo](https://github.com/hhxsv5/laravel-s/blob/master/KnownIssues.md#singleton-controller).
 
+## expose_swoole_http_response
+> `bool` Whether to expose the `Swoole\Http\Response` object for direct response with this object, such as calling its write(), sendfile() and other methods, but Laravel after-middleware may not work properly, default `false`.
+
 ## swoole
 > `array` Swoole's `original` configuration items, refer [Swoole Server Configuration](https://www.swoole.co.uk/docs/modules/swoole-server/configuration).

--- a/config/laravels.php
+++ b/config/laravels.php
@@ -259,7 +259,7 @@ return [
     | Automatically destroy the controllers after each request to solve
     | the problem of the singleton controllers.
     |
-    | https://github.com/hhxsv5/laravel-s/blob/master/KnownIssues.md#singleton-controller
+    | https://github.com/hhxsv5/laravel-s/blob/master/Settings.md#destroy_controllers
     |
     */
 
@@ -267,6 +267,20 @@ return [
         'enable'        => false,
         'excluded_list' => [],
     ],
+
+    /*
+   |--------------------------------------------------------------------------
+   | Expose Swoole Http Response Object
+   |--------------------------------------------------------------------------
+   |
+   | Whether to expose the `Swoole\Http\Response` object for direct response with this object,
+   | such as calling its write(), sendfile() and other methods, but Laravel after-middleware may not work properly.
+   |
+   | https://github.com/hhxsv5/laravel-s/blob/master/Settings.md#expose_swoole_http_response
+   |
+   */
+
+    'expose_swoole_http_response' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/config/laravels.php
+++ b/config/laravels.php
@@ -270,7 +270,7 @@ return [
 
     /*
    |--------------------------------------------------------------------------
-   | Expose Swoole Http Response Object
+   | Expose Swoole\Http\Response Object
    |--------------------------------------------------------------------------
    |
    | Whether to expose the `Swoole\Http\Response` object for direct response with this object,

--- a/src/Illuminate/Cleaners/RequestCleaner.php
+++ b/src/Illuminate/Cleaners/RequestCleaner.php
@@ -8,9 +8,13 @@ class RequestCleaner extends BaseCleaner
 {
     public function clean()
     {
-        unset($this->currentApp['url'], $this->currentApp['request'], $this->currentApp['swoole-http-response']);
+        $this->currentApp->forgetInstance('url');
         Facade::clearResolvedInstance('url');
+
+        $this->currentApp->forgetInstance('request');
         Facade::clearResolvedInstance('request');
+
+        $this->currentApp->forgetInstance('swoole-http-response');
         Facade::clearResolvedInstance('swoole-http-response');
     }
 }

--- a/src/Illuminate/Cleaners/RequestCleaner.php
+++ b/src/Illuminate/Cleaners/RequestCleaner.php
@@ -8,10 +8,9 @@ class RequestCleaner extends BaseCleaner
 {
     public function clean()
     {
-        $this->currentApp->forgetInstance('url');
+        unset($this->currentApp['url'], $this->currentApp['request'], $this->currentApp['swoole-http-response']);
         Facade::clearResolvedInstance('url');
-        
-        $this->currentApp->forgetInstance('request');
         Facade::clearResolvedInstance('request');
+        Facade::clearResolvedInstance('swoole-http-response');
     }
 }

--- a/src/Illuminate/Laravel.php
+++ b/src/Illuminate/Laravel.php
@@ -238,9 +238,9 @@ class Laravel
         });
     }
 
-    public function bindSwooleResponse(SwooleResponse $response)
+    public function bindSwooleHttpResponse(SwooleResponse $response)
     {
-        $this->currentApp->instance('swoole-response', $response);
+        $this->currentApp->instance('swoole-http-response', $response);
     }
 
     public function saveSession()

--- a/src/Illuminate/Laravel.php
+++ b/src/Illuminate/Laravel.php
@@ -6,6 +6,7 @@ use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel as ConsoleKernel;
 use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Http\Request as IlluminateRequest;
+use Swoole\Http\Response as SwooleResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -235,6 +236,11 @@ class Laravel
         $this->currentApp->singleton('swoole', function () use ($swoole) {
             return $swoole;
         });
+    }
+
+    public function bindSwooleResponse(SwooleResponse $response)
+    {
+        $this->currentApp->instance('swoole-response', $response);
     }
 
     public function saveSession()

--- a/src/LaravelS.php
+++ b/src/LaravelS.php
@@ -191,6 +191,7 @@ class LaravelS extends Server
         try {
             $laravelRequest = $this->convertRequest($this->laravel, $swooleRequest);
             $this->laravel->bindRequest($laravelRequest);
+            $this->laravel->bindSwooleResponse($swooleResponse);
             $this->laravel->fireEvent('laravels.received_request', [$laravelRequest]);
             $handleStaticSuccess = false;
             if ($this->conf['handle_static']) {

--- a/src/LaravelS.php
+++ b/src/LaravelS.php
@@ -76,9 +76,6 @@ class LaravelS extends Server
         // Start Laravel's lifetime, then support session ...middleware.
         $laravelRequest = $this->convertRequest($this->laravel, $request);
         $this->laravel->bindRequest($laravelRequest);
-        if (!empty($this->conf['expose_swoole_http_response'])) {
-            $this->laravel->bindSwooleHttpResponse($response);
-        }
         $this->laravel->fireEvent('laravels.received_request', [$laravelRequest]);
         $this->laravel->cleanProviders();
         $laravelResponse = $this->laravel->handleDynamic($laravelRequest);
@@ -194,9 +191,6 @@ class LaravelS extends Server
         try {
             $laravelRequest = $this->convertRequest($this->laravel, $swooleRequest);
             $this->laravel->bindRequest($laravelRequest);
-            if (!empty($this->conf['expose_swoole_http_response'])) {
-                $this->laravel->bindSwooleHttpResponse($swooleResponse);
-            }
             $this->laravel->fireEvent('laravels.received_request', [$laravelRequest]);
             $handleStaticSuccess = false;
             if ($this->conf['handle_static']) {
@@ -204,6 +198,9 @@ class LaravelS extends Server
                 $handleStaticSuccess = $this->handleStaticResource($this->laravel, $laravelRequest, $swooleResponse);
             }
             if (!$handleStaticSuccess) {
+                if (!empty($this->conf['expose_swoole_http_response'])) {
+                    $this->laravel->bindSwooleHttpResponse($swooleResponse);
+                }
                 $this->handleDynamicResource($this->laravel, $laravelRequest, $swooleResponse);
             }
         } catch (\Exception $e) {

--- a/src/LaravelS.php
+++ b/src/LaravelS.php
@@ -71,7 +71,7 @@ class LaravelS extends Server
         }
     }
 
-    protected function beforeWebSocketHandShake(SwooleRequest $request, SwooleResponse $response)
+    protected function beforeWebSocketHandShake(SwooleRequest $request)
     {
         // Start Laravel's lifetime, then support session ...middleware.
         $laravelRequest = $this->convertRequest($this->laravel, $request);
@@ -92,7 +92,7 @@ class LaravelS extends Server
     protected function triggerWebSocketEvent($event, array $params)
     {
         if ($event === 'onHandShake') {
-            $this->beforeWebSocketHandShake($params[0], $params[1]);
+            $this->beforeWebSocketHandShake($params[0]);
             $params[1]->header('Server', $this->conf['server']);
         }
 
@@ -116,7 +116,7 @@ class LaravelS extends Server
     {
         switch ($event) {
             case 'onHandShake':
-                $this->beforeWebSocketHandShake($params[0], $params[1]);
+                $this->beforeWebSocketHandShake($params[0]);
             case 'onRequest':
                 $params[1]->header('Server', $this->conf['server']);
                 break;

--- a/src/Swoole/Response.php
+++ b/src/Swoole/Response.php
@@ -98,6 +98,10 @@ abstract class Response implements ResponseInterface
 
     public function send($gzip = false)
     {
+        if (!empty($this->swooleResponse->isEnded)) {
+            // For calling Swoole\Http\Response->end() in Laravel
+            return;
+        }
         $this->sendStatusCode();
         $this->sendHeaders();
         $this->sendCookies();

--- a/src/Swoole/Response.php
+++ b/src/Swoole/Response.php
@@ -98,10 +98,6 @@ abstract class Response implements ResponseInterface
 
     public function send($gzip = false)
     {
-        if (!empty($this->swooleResponse->isEnded)) {
-            // For calling Swoole\Http\Response->end() in Laravel
-            return;
-        }
         $this->sendStatusCode();
         $this->sendHeaders();
         $this->sendCookies();


### PR DESCRIPTION
```php
// Set expose_swoole_http_response to true
$router->get('/custom-swoole-response', function () use ($router) {
    /**@var \Swoole\Http\Response $swooleResponse */
    $swooleResponse = app('swoole-http-response');
    $swooleResponse->end('swoole response');
    $swooleResponse->isEnded = true; // isEnded must be set to true, indicating that the underlying Swoole\Http\Response object is directly used to process the response, so the response content is "swoole response" instead of "laravel response".
    return 'laravel response';
});
```