### PR TITLE
Fix the type conversion of cookie `value` and `domain` name in Respon…

### DIFF
--- a/src/Swoole/Response.php
+++ b/src/Swoole/Response.php
@@ -86,10 +86,10 @@ abstract class Response implements ResponseInterface
             $setCookie = $hasIsRaw && $cookie->isRaw() ? 'rawcookie' : 'cookie';
             $this->swooleResponse->$setCookie(
                 $cookie->getName(),
-                $cookie->getValue(),
+                (string)$cookie->getValue(),
                 $cookie->getExpiresTime(),
                 $cookie->getPath(),
-                $cookie->getDomain(),
+                (string)$cookie->getDomain(),
                 $cookie->isSecure(),
                 $cookie->isHttpOnly()
             );


### PR DESCRIPTION
Fix the type conversion of cookie `value` and `domain` name in Response class to ensure they are a string type

#495