### PR TITLE
Feature/support using namespae prefixes exluding clean controller

### DIFF
--- a/KnownIssues-CN.md
+++ b/KnownIssues-CN.md
@@ -141,9 +141,14 @@ class TestController extends Controller
     'enable'        => true, // 启用自动销毁控制器
     'excluded_list' => [
         //\App\Http\Controllers\TestController::class, // 排除销毁的控制器类列表
+        //'App\Http\Controllers\V2\*', // 支持使用通配符的命名空间前缀匹配，该命名空间下的所有控制器都会被排除
     ],
 ],
 ```
+
+有两种方式可以排除控制器不被销毁：
+1. 精确匹配：指定完整的类名
+2. 前缀匹配：在命名空间末尾使用通配符(*)，例如 `App\Http\Controllers\V2\*` 将排除该命名空间下的所有控制器
 
 ## 不能使用这些函数
 

--- a/KnownIssues.md
+++ b/KnownIssues.md
@@ -138,9 +138,14 @@ class TestController extends Controller
     'enable'        => true, // Enable automatic destruction controller
     'excluded_list' => [
         //\App\Http\Controllers\TestController::class, // The excluded list of destroyed controller classes
+        //'App\Http\Controllers\V2\*', // Support namespace prefix with wildcard, all controllers under this namespace will be excluded
     ],
 ],
 ```
+
+There are two ways to exclude controllers from being destroyed:
+1. Exact match: specify the full class name
+2. Prefix match: use wildcard (*) at the end of namespace, for example `App\Http\Controllers\V2\*` will exclude all controllers under this namespace
 
 ## Cannot call these functions
 


### PR DESCRIPTION
- Add support for excluding controllers by namespace prefix using wildcard (*)
- Add new property `$whiteListPrefixes` to store prefix patterns
- Add new method `shouldExcludeController` to handle both exact and prefix matches

Example:
`App\Http\Controllers\V2\*` will exclude all controllers under V2 namespace